### PR TITLE
Feat: Search Only First Index By Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ When more than one bias is configured, the following priority is used:
 
 ```javascript
 const results = await search.query('configuration', {
+  searchAllIndexes: true,
   platform: 'sentry.erlang',
 });
 ```
@@ -83,6 +84,8 @@ const results = await search.query('configuration', {
 - `path` — String of a path in the format of `/foo/bar/`. Results with a path matching or subornate will appear first.
 
 - `platform` — String of a valid [SDK slug][sdk-slug-format]. Results matching this slug will appear first or after `path` results.
+
+- `searchAllIndexes` — Boolean, defalt false. Searches all configured indexes if true. Otherwise, search only the first.
 
 ### Results
 

--- a/src/sentry-global-search/__snapshots__/sentry-global-search.test.js.snap
+++ b/src/sentry-global-search/__snapshots__/sentry-global-search.test.js.snap
@@ -19,48 +19,6 @@ Array [
         },
         "query": "react",
       },
-      Object {
-        "indexName": "develop-docs",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            Array [
-              "platforms:sentry.javascript.react",
-            ],
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "sentry-blog-posts",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            Array [
-              "platforms:sentry.javascript.react",
-            ],
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "sentry-help",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            "pathSegments:/foo/bar/",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
     ],
   ],
 ]
@@ -72,42 +30,6 @@ Array [
     Array [
       Object {
         "indexName": "sentry-docs",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "develop-docs",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "sentry-blog-posts",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "sentry-help",
         "params": Object {
           "highlightPostTag": "</mark>",
           "highlightPreTag": "<mark>",
@@ -142,57 +64,43 @@ Array [
         },
         "query": "react",
       },
-      Object {
-        "indexName": "develop-docs",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            Array [
-              "platforms:sentry.javascript.react",
-            ],
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "sentry-blog-posts",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            Array [
-              "platforms:sentry.javascript.react",
-            ],
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "sentry-help",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            Array [
-              "platforms:sentry.javascript.react",
-            ],
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
     ],
   ],
 ]
 `;
 
 exports[`Search queries 1`] = `
+Array [
+  Object {
+    "hits": Array [
+      Object {
+        "context": Object {
+          "context1": "Platforms > JavaScript > React",
+        },
+        "id": "cd5528ad-935b-5a33-b25e-4f945638551b",
+        "site": "docs",
+        "text": "Mocked text",
+        "title": "Mocked section",
+        "url": "https://docs.sentry.io/platforms/javascript/react/",
+      },
+      Object {
+        "context": Object {
+          "context1": "Platforms > JavaScript > React",
+        },
+        "id": "cd5528ad-935b-5a33-b25e-4f945638551b",
+        "site": "docs",
+        "text": "Mocked text",
+        "title": "Mocked section",
+        "url": "https://docs.sentry.io/platforms/javascript/react/",
+      },
+    ],
+    "name": "Documentation",
+    "site": "docs",
+  },
+]
+`;
+
+exports[`Search queries multiple indexes 1`] = `
 Array [
   Object {
     "hits": Array [
@@ -313,42 +221,6 @@ Array [
         },
         "query": "react",
       },
-      Object {
-        "indexName": "develop-docs",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "sentry-blog-posts",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "sentry-help",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
     ],
   ],
 ]
@@ -360,51 +232,6 @@ Array [
     Array [
       Object {
         "indexName": "sentry-docs",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            Array [
-              "platforms:sentry.javascript.react",
-            ],
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "develop-docs",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            Array [
-              "platforms:sentry.javascript.react",
-            ],
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "sentry-blog-posts",
-        "params": Object {
-          "highlightPostTag": "</mark>",
-          "highlightPreTag": "<mark>",
-          "optionalFilters": Array [
-            Array [
-              "platforms:sentry.javascript.react",
-            ],
-            "legacy:0",
-          ],
-          "snippetEllipsisText": "…",
-        },
-        "query": "react",
-      },
-      Object {
-        "indexName": "sentry-help",
         "params": Object {
           "highlightPostTag": "</mark>",
           "highlightPreTag": "<mark>",

--- a/src/sentry-global-search/components/search.tsx
+++ b/src/sentry-global-search/components/search.tsx
@@ -55,6 +55,21 @@ const Search: React.FC<Props> = ({ platforms, path }) => {
 
   const totalHits = results.reduce((a, x) => a + x.hits.length, 0);
 
+  const searchFor = (query, args = {}) => {
+    setQuery(query);
+    search
+      .query(query, {
+        platforms,
+        path,
+        searchAllIndexes: showOffsiteResults,
+        ...args,
+      })
+      .then(results => {
+        if (loading) setLoading(false);
+        setResults(results);
+      });
+  };
+
   return (
     <div ref={ref}>
       <input
@@ -63,11 +78,7 @@ const Search: React.FC<Props> = ({ platforms, path }) => {
         aria-label="Search"
         className="form-control"
         onChange={({ target: { value: query } }) => {
-          setQuery(query);
-          search.query(query, { platforms, path }).then(results => {
-            if (loading) setLoading(false);
-            setResults(results);
-          });
+          searchFor(query);
         }}
         value={query}
         onFocus={() => setFocus(true)}
@@ -155,7 +166,13 @@ const Search: React.FC<Props> = ({ platforms, path }) => {
                   <div className="sgs-expand-results">
                     <button
                       className="sgs-expand-results-button"
-                      onClick={() => setShowOffsiteResults(true)}
+                      onClick={() => {
+                        setShowOffsiteResults(true);
+                      }}
+                      onMouseOver={() => {
+                        // Prefetch the results from all queries if it looks like they're going to be needed.
+                        searchFor(query, { searchAllIndexes: true });
+                      }}
                     >
                       Search <em>{query}</em> across all Sentry sites
                     </button>

--- a/src/sentry-global-search/sentry-global-search.test.js
+++ b/src/sentry-global-search/sentry-global-search.test.js
@@ -45,6 +45,14 @@ describe('Search', () => {
     expect(results).toMatchSnapshot();
   });
 
+  test('queries multiple indexes', async () => {
+    const search = new SentryGlobalSearch(config);
+    const results = await search.query('react', {
+      searchAllIndexes: true,
+    });
+    expect(results).toMatchSnapshot();
+  });
+
   test('queries with platform priority', async () => {
     const search = new SentryGlobalSearch(config);
     const results = await search.query('react', {


### PR DESCRIPTION
We've been fetching all configured indexes whether they are displayed are not. Since most searching behavior happens without "viewing all sites", we're wasting a lot of bandwidth on unused data. This switches thing to only search the first index by default, and allow to opting into all indexes.