### PR TITLE
ref(ci): fix set-output / set-state deprecation

### DIFF
--- a/.github/workflows/syncSynonyms.yml
+++ b/.github/workflows/syncSynonyms.yml
@@ -17,7 +17,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: |
-          echo "::set-output name=result::$(git diff --name-only HEAD^ HEAD ./config/algolia-synonyms.yml)"
+          echo "result=$(git diff --name-only HEAD^ HEAD ./config/algolia-synonyms.yml)" >> "$GITHUB_OUTPUT"
         id: synonyms_changed
       - run: yarn sync-synonyms
         if: steps.synonyms_changed.outputs.result == 'config/algolia-synonyms.yml'


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Committed via https://github.com/asottile/all-repos