### PR TITLE
feat(search): allow clickAnalytics and pass results to transformer

### DIFF
--- a/src/sentry-global-search/__snapshots__/sentry-global-search.test.js.snap
+++ b/src/sentry-global-search/__snapshots__/sentry-global-search.test.js.snap
@@ -1,5 +1,175 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Search calls search with clickAnalytics 1`] = `
+Array [
+  Array [
+    Array [
+      Object {
+        "indexName": "blog",
+        "params": Object {
+          "clickAnalytics": true,
+          "highlightPostTag": "</mark>",
+          "highlightPreTag": "<mark>",
+          "optionalFilters": Array [
+            Array [
+              "platforms:sentry.javascript.react",
+            ],
+            "legacy:0",
+          ],
+          "snippetEllipsisText": "…",
+        },
+        "query": "react",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`Search calls transformer with response 1`] = `
+Object {
+  "exhaustiveNbHits": true,
+  "hits": Array [
+    Object {
+      "_highlightResult": Object {
+        "excerpt": Object {
+          "fullyHighlighted": false,
+          "matchLevel": "full",
+          "matchedWords": Array [
+            "react",
+          ],
+          "value": "Mocked excerpt",
+        },
+        "fields": Object {
+          "slug": Object {
+            "fullyHighlighted": false,
+            "matchLevel": "full",
+            "matchedWords": Array [
+              "react",
+            ],
+            "value": "/platforms/javascript/<mark>react</mark>/",
+          },
+        },
+        "section": Object {
+          "matchLevel": "none",
+          "matchedWords": Array [],
+          "value": "Mocked section",
+        },
+        "title": Object {
+          "fullyHighlighted": true,
+          "matchLevel": "full",
+          "matchedWords": Array [
+            "react",
+          ],
+          "value": "<mark>React</mark>",
+        },
+      },
+      "_snippetResult": Object {
+        "body_safe": Object {
+          "matchLevel": "full",
+          "value": "Mocked body_safe",
+        },
+        "content": Object {
+          "matchLevel": "full",
+          "value": "MockedContent",
+        },
+        "excerpt": Object {
+          "matchLevel": "full",
+          "value": "Mocked excerpt",
+        },
+        "text": Object {
+          "matchLevel": "full",
+          "value": "Mocked text",
+        },
+      },
+      "draft": false,
+      "excerpt": "Mocked excerpt",
+      "fields": Object {
+        "slug": "/platforms/javascript/react/",
+      },
+      "objectID": "cd5528ad-935b-5a33-b25e-4f945638551b",
+      "section": Object {
+        "full_path": "Mocked full_path",
+      },
+      "title": "Mocked hit",
+      "url": "/platforms/javascript/react/",
+    },
+    Object {
+      "_highlightResult": Object {
+        "excerpt": Object {
+          "fullyHighlighted": false,
+          "matchLevel": "full",
+          "matchedWords": Array [
+            "react",
+          ],
+          "value": "Mocked excerpt",
+        },
+        "fields": Object {
+          "slug": Object {
+            "fullyHighlighted": false,
+            "matchLevel": "full",
+            "matchedWords": Array [
+              "react",
+            ],
+            "value": "/platforms/javascript/<mark>react</mark>/",
+          },
+        },
+        "section": Object {
+          "matchLevel": "none",
+          "matchedWords": Array [],
+          "value": "Mocked section",
+        },
+        "title": Object {
+          "fullyHighlighted": true,
+          "matchLevel": "full",
+          "matchedWords": Array [
+            "react",
+          ],
+          "value": "<mark>React</mark>",
+        },
+      },
+      "_snippetResult": Object {
+        "body_safe": Object {
+          "matchLevel": "full",
+          "value": "Mocked body_safe",
+        },
+        "content": Object {
+          "matchLevel": "full",
+          "value": "MockedContent",
+        },
+        "excerpt": Object {
+          "matchLevel": "full",
+          "value": "Mocked excerpt",
+        },
+        "text": Object {
+          "matchLevel": "full",
+          "value": "Mocked text",
+        },
+      },
+      "anchor": "mocked-anchor",
+      "draft": false,
+      "excerpt": "Mocked excerpt",
+      "fields": Object {
+        "slug": "/platforms/javascript/react/",
+      },
+      "objectID": "cd5528ad-935b-5a33-b25e-4f945638551b",
+      "section": Object {
+        "full_path": "Mocked full_path",
+      },
+      "title": "Mocked hit",
+      "url": "/platforms/javascript/react/",
+    },
+  ],
+  "hitsPerPage": 20,
+  "index": "sentry-blog-posts",
+  "nbHits": 1,
+  "nbPages": 1,
+  "page": 0,
+  "params": "query=react&snippetEllipsisText=%E2%80%A6&highlightPreTag=%3Cmark%3E&highlightPostTag=%3C%2Fmark%3E",
+  "processingTimeMS": 13,
+  "query": "react",
+}
+`;
+
 exports[`Search can bias individual sites 1`] = `
 Array [
   Array [

--- a/src/sentry-global-search/lib/types.ts
+++ b/src/sentry-global-search/lib/types.ts
@@ -1,4 +1,4 @@
-import { ObjectWithObjectID } from '@algolia/client-search';
+import { ObjectWithObjectID, SearchResponse } from '@algolia/client-search';
 
 export type Site = 'docs' | 'develop' | 'help-center' | 'blog';
 
@@ -128,9 +128,13 @@ export type Index = {
    */
   indexName: string;
   /**
+   * Enables clickAnalytics for this search which generates a queryID
+   */
+  clickAnalytics?: boolean;
+  /**
    * Function use to transform algolia results to a `Hit` objects
    */
   transformer: Transformer;
 };
 
-export type Transformer = (hit: SearchHit) => Hit;
+export type Transformer = (hit: SearchHit, results: SearchResponse) => Hit;

--- a/src/sentry-global-search/sentry-global-search.test.js
+++ b/src/sentry-global-search/sentry-global-search.test.js
@@ -102,4 +102,39 @@ describe('Search', () => {
     });
     expect(client.search.mock.calls).toMatchSnapshot();
   });
+
+  test('calls search with clickAnalytics', async () => {
+    const search = new SentryGlobalSearch([{
+      site: "blog",
+      indexes: [{
+        indexName: "blog",
+        clickAnalytics: true,
+      }]
+    }]);
+
+    const results = await search.query('react', {
+      path: ['/foo/bar/'],
+      platforms: ['sentry.javascript.react'],
+      legacy: true,
+    });
+    expect(client.search.mock.calls).toMatchSnapshot();
+  });
+
+  test('calls transformer with response', async () => {
+    const config = [{
+      site: "blog",
+      indexes: [{
+        indexName: "sentry-blog-posts",
+        clickAnalytics: true,
+        transformer: jest.fn()
+      }]
+    }]
+
+    const search = new SentryGlobalSearch(config);
+    await search.query('react')
+
+    expect(config[0].indexes[0].transformer).toHaveBeenCalledTimes(2);
+    expect(config[0].indexes[0].transformer.mock.calls[0][1]).toMatchSnapshot();
+    expect(config[0].indexes[0].transformer.mock.calls[0][1].hitsPerPage).toBe(20)
+  });
 });


### PR DESCRIPTION
Allow passing of query options and provide transformer with entire response object so that we can pull queryID from results in the future so we can pass it for clickAnalytics