### PR TITLE
update major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry-internal/global-search",
   "description": "JavaScript library and helper utilities for searching Sentry sites via Algolia.",
-  "version": "0.5.10",
+  "version": "1.0.0",
   "author": "Sentry",
   "dependencies": {
     "@types/react": ">=16",


### PR DESCRIPTION
update major version to prevent sentry and static-sites from using the latest release automatically when it's cut