### PR TITLE
fix: Remove top-level node sdk from slugs

### DIFF
--- a/config/index-names.ts
+++ b/config/index-names.ts
@@ -1,7 +1,0 @@
-export const indexNames = {
-  USER_DOCS: 'sentry-docs-v2',
-  DEVELOP_DOCS: 'develop-docs',
-  HELP_CENTER: 'sentry-help',
-  ZENDESK: 'zendesk_sentry_articles',
-  BLOG: 'sentry-blog-posts',
-};

--- a/config/index-names.ts
+++ b/config/index-names.ts
@@ -1,0 +1,7 @@
+export const indexNames = {
+  USER_DOCS: 'sentry-docs-v2',
+  DEVELOP_DOCS: 'develop-docs',
+  HELP_CENTER: 'sentry-help',
+  ZENDESK: 'zendesk_sentry_articles',
+  BLOG: 'sentry-blog-posts',
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry-internal/global-search",
   "description": "JavaScript library and helper utilities for searching Sentry sites via Algolia.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Sentry",
   "dependencies": {
     "@types/react": ">=16",

--- a/scripts/syncSynonyms.ts
+++ b/scripts/syncSynonyms.ts
@@ -3,7 +3,7 @@ import yaml from 'js-yaml';
 import fs from 'fs';
 import path from 'path';
 import { createHash } from 'crypto';
-import { indexNames } from '../config/index-names';
+import { indexNames } from '../src/sentry-global-search/lib/config';
 
 // Algolia treats synonyms like records, so they cannot be sent as settings
 // when an index is sent, at least via the Gatsby plugin we use. This script

--- a/scripts/syncSynonyms.ts
+++ b/scripts/syncSynonyms.ts
@@ -3,13 +3,14 @@ import yaml from 'js-yaml';
 import fs from 'fs';
 import path from 'path';
 import { createHash } from 'crypto';
+import { indexNames } from '../config/index-names';
 
 // Algolia treats synonyms like records, so they cannot be sent as settings
 // when an index is sent, at least via the Gatsby plugin we use. This script
 // syncs our synonym config with all the indexes we have indicated should use
 // these synonym settings.
 //
-// See src/algolia-synonyms.yml for the actual synonym config
+// See config/algolia-synonyms.yml for the actual synonym config
 
 type Config = {
   synonym: string[][];
@@ -18,10 +19,10 @@ type Config = {
 };
 
 const SYNCED_INDEXES = [
-  'sentry-docs',
-  'develop-docs',
-  'sentry-help',
-  'sentry-blog-posts',
+  indexNames.USER_DOCS,
+  indexNames.DEVELOP_DOCS,
+  indexNames.HELP_CENTER,
+  indexNames.BLOG,
 ] as const;
 
 if (!process.env.ALGOLIA_ADMIN_KEY) {

--- a/src/sentry-global-search/lib/config.ts
+++ b/src/sentry-global-search/lib/config.ts
@@ -4,8 +4,8 @@ import { Config } from './types';
 import * as Transformers from './transformers';
 
 export const indexNames = {
-  // USER_DOCS: 'sentry-docs-v2',
-  USER_DOCS: 'testing-docs',
+  USER_DOCS: 'sentry-docs-v2',
+  TESTING_DOCS: 'testing-docs', // can be used for local development instead of USER_DOCS
   DEVELOP_DOCS: 'develop-docs',
   HELP_CENTER: 'sentry-help',
   ZENDESK: 'zendesk_sentry_articles',

--- a/src/sentry-global-search/lib/config.ts
+++ b/src/sentry-global-search/lib/config.ts
@@ -10,7 +10,7 @@ export const indexNames = {
   HELP_CENTER: 'sentry-help',
   ZENDESK: 'zendesk_sentry_articles',
   BLOG: 'sentry-blog-posts',
-};
+} as const;
 
 const config = (
   settings: Omit<Config, 'pathBias' | 'platformBias' | 'legacyBias'>

--- a/src/sentry-global-search/lib/config.ts
+++ b/src/sentry-global-search/lib/config.ts
@@ -2,7 +2,15 @@ import { SearchOptions } from '@algolia/client-search';
 
 import { Config } from './types';
 import * as Transformers from './transformers';
-import { indexNames } from '../../../config/index-names';
+
+export const indexNames = {
+  // USER_DOCS: 'sentry-docs-v2',
+  USER_DOCS: 'testing-docs',
+  DEVELOP_DOCS: 'develop-docs',
+  HELP_CENTER: 'sentry-help',
+  ZENDESK: 'zendesk_sentry_articles',
+  BLOG: 'sentry-blog-posts',
+};
 
 const config = (
   settings: Omit<Config, 'pathBias' | 'platformBias' | 'legacyBias'>

--- a/src/sentry-global-search/lib/config.ts
+++ b/src/sentry-global-search/lib/config.ts
@@ -2,6 +2,7 @@ import { SearchOptions } from '@algolia/client-search';
 
 import { Config } from './types';
 import * as Transformers from './transformers';
+import { indexNames } from '../../../config/index-names';
 
 const config = (
   settings: Omit<Config, 'pathBias' | 'platformBias' | 'legacyBias'>
@@ -26,7 +27,7 @@ export const sites = [
     name: 'Documentation',
     indexes: [
       {
-        indexName: 'sentry-docs-v2',
+        indexName: indexNames.USER_DOCS,
         transformer: Transformers.transformDocsGatsbyHit,
       },
     ],
@@ -36,7 +37,7 @@ export const sites = [
     name: 'Developer Documentation',
     indexes: [
       {
-        indexName: 'develop-docs',
+        indexName: indexNames.DEVELOP_DOCS,
         transformer: Transformers.transformDevelopHit,
       },
     ],
@@ -46,7 +47,7 @@ export const sites = [
     name: 'Help Center',
     indexes: [
       {
-        indexName: 'sentry-help',
+        indexName: indexNames.HELP_CENTER,
         transformer: Transformers.transformHelpCenterHit,
       },
     ],
@@ -56,7 +57,7 @@ export const sites = [
     name: 'Help Center',
     indexes: [
       {
-        indexName: 'zendesk_sentry_articles',
+        indexName: indexNames.ZENDESK,
         transformer: Transformers.transformZendeskArticlesHit,
       },
     ],
@@ -66,7 +67,7 @@ export const sites = [
     name: 'Blog Posts',
     indexes: [
       {
-        indexName: 'sentry-blog-posts',
+        indexName: indexNames.BLOG,
         transformer: Transformers.transformBlogHit,
       },
     ],

--- a/src/sentry-global-search/lib/standard-sdk-slug.ts
+++ b/src/sentry-global-search/lib/standard-sdk-slug.ts
@@ -14,7 +14,6 @@ const names = {
   'sentry.python': 'Python',
   'sentry.php': 'PHP',
   'sentry.perl': 'Perl',
-  'sentry.node': 'Node',
   'sentry.native': 'Native',
   'sentry.javascript': 'JavaScript',
   'sentry.java': 'Java',
@@ -33,7 +32,6 @@ const synonyms = {
   python: 'sentry.python',
   php: 'sentry.php',
   perl: 'sentry.perl',
-  node: 'sentry.node',
   native: 'sentry.native',
   javascript: 'sentry.javascript',
   java: 'sentry.java',
@@ -62,4 +60,3 @@ export const standardSDKSlug = (slug: string) => {
     name,
   };
 };
-


### PR DESCRIPTION
- single source for index names (synonyms have been synced to wrong index all the time) 
- removes top-level node sdk as this does not match our docs structure anymore

relates to [#10592](https://github.com/getsentry/sentry-docs/issues/10592)