### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 ## Legal
 /LICENSE.md                                              @getsentry/owners-legal
 
-*                                                        @getsentry/devrel
+*                                                        @getsentry/devex-eng


### PR DESCRIPTION
Working with Cody on renaming the teams, the codeowner file will be valid once this PR is merged: https://github.com/getsentry/security-as-code/pull/1873